### PR TITLE
修改captcha.php中的一处笔误，会导致Nginx报错

### DIFF
--- a/app/captcha.php
+++ b/app/captcha.php
@@ -59,4 +59,4 @@ for ($i = 0; $i < 5; $i++) {
 // 因为有些浏览器，访问的content-type会是文本型，所以我们需要设置成图片的格式类型
 header("content-type:image/png");
 imagepng($img); //建立png函数
-imagedestroy($image);
+imagedestroy($img);


### PR DESCRIPTION
/app/captcha.php中有一处小笔误，原代码中：

- 图像资源变量始终使用 $img（正确的变量名）

- 最后误写为 imagedestroy($image)（错误的变量名），这导致 PHP 尝试销毁一个不存在的 $image 变量，引发 Undefined variable 警告和 null 参数错误。

Nginx报错信息：

```log
xxxx/xx/xx xx:xx:xx [error] 1000233#1000233: *18 FastCGI sent in stderr: "PHP message: PHP Warning:  Undefined variable $image in /xxxx/xx/EasyImages2.0/app/captcha.php on line 62; PHP message: PHP Fatal error:  Uncaught TypeError: imagedestroy(): Argument #1 ($image) must be of type GdImage, null given in /xxxx/xx/EasyImages2.0/app/captcha.php:62
Stack trace:
#0 /xxxx/xx/EasyImages2.0/app/captcha.php(62): imagedestroy()
#1 {main}
  thrown in /xxxx/xx/EasyImages2.0/app/captcha.php on line 62" while reading upstream, client: xxx.xxx.xxx.xxx, server: img.website.com, request: "GET /app/captcha.php HTTP/2.0", upstream: "fastcgi://unix:/run/php/php8.3-fpm.sock:", host: "img.website.com", referrer: "https://img.website.com/admin/index.php"
```

每次在登录页面点击“登录”按钮都会出现一次相同的报错。

将 $image 改为 $img 后，代码会正确销毁实际存在的图像资源，两个错误都会消失。