### PR TITLE
解决在alpine镜像中运行的报错——Undefined constant "GLOB_BRACE"

### DIFF
--- a/app/function.php
+++ b/app/function.php
@@ -462,7 +462,8 @@ function get_file_by_glob($dir_fileName_suffix, $type = 'list')
 
     // 获取所有文件
     if ($type == 'list') {
-        $glob = glob($dir_fileName_suffix, GLOB_BRACE);
+        $flag = defined('GLOB_BRACE') ? GLOB_BRACE : 0;
+        $glob = glob($dir_fileName_suffix, $flag);
 
         if ($glob) {
             foreach ($glob as $v) {


### PR DESCRIPTION
解决在alpine镜像中运行的报错。（PHP手册: GLOB_BRACE 在一些非 GUN 系统无效，像 Solaris 或 Alpine Linux。）

NOTICE: PHP message: PHP Fatal error:  Uncaught Error: Undefined constant "GLOB_BRACE" in /opt/htdocs/easyimages/app/function.php:465
Stack trace:
#0 /opt/htdocs/easyimages/admin/admin.inc.php(864): get_file_by_glob()
